### PR TITLE
fix: handle invalid encoding in stack trace during failure serialization

### DIFF
--- a/lib/temporal/connection/serializer/failure.rb
+++ b/lib/temporal/connection/serializer/failure.rb
@@ -1,4 +1,4 @@
-require 'temporal/connection/serializer/base'
+require "temporal/connection/serializer/base"
 
 module Temporal
   module Connection
@@ -11,24 +11,8 @@ module Temporal
         end
 
         def to_proto
-          if @serialize_whole_error
-            details = converter.to_details_payloads(object)
-            if details.payloads.first.data.size > @max_bytes
-              Temporal.logger.error(
-                "Could not serialize exception because it's too large, so we are using a fallback that may not "\
-                  "deserialize correctly on the client.  First #{@max_bytes} bytes:\n" \
-                "#{details.payloads.first.data[0..@max_bytes - 1]}",
-                {unserializable_error: object.class.name}
-              )
-              # Fallback to a more conservative serialization if the payload is too big to avoid
-              # sending a huge amount of data to temporal and putting it in the history.
-              details = converter.to_details_payloads(object.message)
-            end
-          else
-            details = converter.to_details_payloads(object.message)
-          end
           Temporalio::Api::Failure::V1::Failure.new(
-            message: object.message,
+            message: message,
             stack_trace: stack_trace_from(object.backtrace),
             application_failure_info: Temporalio::Api::Failure::V1::ApplicationFailureInfo.new(
               type: object.class.name,
@@ -39,10 +23,44 @@ module Temporal
 
         private
 
+        def details
+          return converter.to_details_payloads(message) unless @serialize_whole_error
+
+          details = converter.to_details_payloads(object)
+          if details.payloads.first.data.size > @max_bytes
+            Temporal.logger.error(
+              "Could not serialize exception because it's too large, so we are using a fallback that may not " \
+                "deserialize correctly on the client.  First #{@max_bytes} bytes:\n" \
+              "#{details.payloads.first.data[0..@max_bytes - 1]}",
+              {unserializable_error: object.class.name}
+            )
+            # Fallback to a more conservative serialization if the payload is too big to avoid
+            # sending a huge amount of data to temporal and putting it in the history.
+            details = converter.to_details_payloads(message)
+          end
+          details
+        rescue => e
+          Temporal.logger.error(
+            "Could not serialize exception details, falling back to the error message only",
+            {unserializable_error: object.class.name, error: e.inspect}
+          )
+          converter.to_details_payloads(message)
+        end
+
+        def message
+          @message ||= scrub_invalid_encoding(object.message)
+        end
+
         def stack_trace_from(backtrace)
           return unless backtrace
 
-          backtrace.join("\n")
+          scrub_invalid_encoding(backtrace.join("\n"))
+        end
+
+        def scrub_invalid_encoding(string)
+          return string if string.nil?
+
+          string.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
         end
       end
     end

--- a/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
@@ -1,5 +1,5 @@
-require 'temporal/connection/serializer/failure'
-require 'temporal/workflow/command'
+require "temporal/connection/serializer/failure"
+require "temporal/workflow/command"
 
 describe Temporal::Connection::Serializer::Failure do
   let(:converter) do
@@ -9,9 +9,9 @@ describe Temporal::Connection::Serializer::Failure do
     )
   end
 
-  describe 'to_proto' do
-    it 'produces a protobuf' do
-      result = described_class.new(StandardError.new('test'), converter).to_proto
+  describe "to_proto" do
+    it "produces a protobuf" do
+      result = described_class.new(StandardError.new("test"), converter).to_proto
 
       expect(result).to be_an_instance_of(Temporalio::Api::Failure::V1::Failure)
     end
@@ -31,57 +31,56 @@ describe Temporal::Connection::Serializer::Failure do
       end
     end
 
-    it 'Serializes round-trippable full errors when asked to' do
+    it "Serializes round-trippable full errors when asked to" do
       # Make sure serializing various bits round-trips
-      e = MyError.new(['seven', 'three'], "Bar", bad_class: NaughtyClass)
+      e = MyError.new(["seven", "three"], "Bar", bad_class: NaughtyClass)
       failure_proto = described_class.new(e, converter, serialize_whole_error: true).to_proto
       expect(failure_proto.application_failure_info.type).to eq("MyError")
 
       deserialized_error = converter.from_details_payloads(failure_proto.application_failure_info.details)
       expect(deserialized_error).to be_an_instance_of(MyError)
       expect(deserialized_error.message).to eq("Hello, Bar!")
-      expect(deserialized_error.foo).to eq(['seven', 'three'])
+      expect(deserialized_error.foo).to eq(["seven", "three"])
       expect(deserialized_error.bad_class).to eq(NaughtyClass)
     end
 
     class MyBigError < StandardError
       attr_reader :big_payload
       def initialize(message)
-        super(message)
-        @big_payload = '123456789012345678901234567890123456789012345678901234567890'
+        super
+        @big_payload = "123456789012345678901234567890123456789012345678901234567890"
       end
     end
 
-
-    it 'deals with too-large serialization using the old path' do
-      e = MyBigError.new('Uh oh!')
+    it "deals with too-large serialization using the old path" do
+      e = MyBigError.new("Uh oh!")
       # Normal serialization path
       failure_proto = described_class.new(e, converter, serialize_whole_error: true, max_bytes: 1000).to_proto
-      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      expect(failure_proto.application_failure_info.type).to eq("MyBigError")
       deserialized_error = converter.from_details_payloads(failure_proto.application_failure_info.details)
       expect(deserialized_error).to be_an_instance_of(MyBigError)
-      expect(deserialized_error.big_payload).to eq('123456789012345678901234567890123456789012345678901234567890')
+      expect(deserialized_error.big_payload).to eq("123456789012345678901234567890123456789012345678901234567890")
 
       # Exercise legacy serialization mechanism
       failure_proto = described_class.new(e, converter, serialize_whole_error: false).to_proto
-      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      expect(failure_proto.application_failure_info.type).to eq("MyBigError")
       old_style_deserialized_error = MyBigError.new(converter.from_details_payloads(failure_proto.application_failure_info.details))
       expect(old_style_deserialized_error).to be_an_instance_of(MyBigError)
-      expect(old_style_deserialized_error.message).to eq('Uh oh!')
+      expect(old_style_deserialized_error.message).to eq("Uh oh!")
 
       # If the payload size exceeds the max_bytes, we fallback to the old-style serialization.
       failure_proto = described_class.new(e, converter, serialize_whole_error: true, max_bytes: 50).to_proto
-      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      expect(failure_proto.application_failure_info.type).to eq("MyBigError")
       avoids_truncation_error = MyBigError.new(converter.from_details_payloads(failure_proto.application_failure_info.details))
       expect(avoids_truncation_error).to be_an_instance_of(MyBigError)
-      expect(avoids_truncation_error.message).to eq('Uh oh!')
+      expect(avoids_truncation_error.message).to eq("Uh oh!")
 
       # Fallback serialization should exactly match legacy serialization
       expect(avoids_truncation_error).to eq(old_style_deserialized_error)
     end
 
-    it 'logs a helpful error when the payload is too large' do 
-      e = MyBigError.new('Uh oh!')
+    it "logs a helpful error when the payload is too large" do
+      e = MyBigError.new("Uh oh!")
 
       allow(Temporal.logger).to receive(:error)
       max_bytes = 50
@@ -89,22 +88,64 @@ describe Temporal::Connection::Serializer::Failure do
       expect(Temporal.logger)
         .to have_received(:error)
         .with(
-          "Could not serialize exception because it's too large, so we are using a fallback that may not deserialize "\
+          "Could not serialize exception because it's too large, so we are using a fallback that may not deserialize " \
           "correctly on the client.  First #{max_bytes} bytes:\n{\"^o\":\"MyBigError\",\"big_payload\":\"1234567890123456",
-          { unserializable_error: 'MyBigError' }
+          {unserializable_error: "MyBigError"}
         )
-
     end
 
     class MyArglessError < RuntimeError
-      def initialize; end
+      def initialize
+      end
     end
 
-    it 'successfully processes an error with no constructor arguments' do 
+    it "successfully processes an error with no constructor arguments" do
       e = MyArglessError.new
       failure_proto = described_class.new(e, converter, serialize_whole_error: true).to_proto
-      expect(failure_proto.application_failure_info.type).to eq('MyArglessError')
+      expect(failure_proto.application_failure_info.type).to eq("MyArglessError")
     end
 
+    it "scrubs invalidly-encoded bytes from the error message" do
+      e = StandardError.new("invalid \xC3 bytes".b)
+
+      failure_proto = described_class.new(e, converter).to_proto
+
+      expect(failure_proto.message).to eq("invalid � bytes")
+      expect(converter.from_details_payloads(failure_proto.application_failure_info.details)).to eq("invalid � bytes")
+    end
+
+    it "scrubs invalidly-encoded bytes from the backtrace" do
+      e = StandardError.new("test")
+      e.set_backtrace(["line \xC3 one".b, "line two"])
+
+      failure_proto = described_class.new(e, converter).to_proto
+
+      expect(failure_proto.stack_trace).to eq("line � one\nline two")
+    end
+
+    it "scrubs invalidly-encoded bytes from the message when serializing the whole error" do
+      e = StandardError.new("invalid \xC3 bytes".b)
+
+      failure_proto = described_class.new(e, converter, serialize_whole_error: true).to_proto
+
+      expect(failure_proto.message).to eq("invalid � bytes")
+    end
+
+    it "falls back to message-only details when whole-error serialization raises" do
+      e = StandardError.new("test")
+      allow(converter).to receive(:to_details_payloads).and_call_original
+      allow(converter).to receive(:to_details_payloads).with(e).and_raise(StandardError, "unserializable")
+      allow(Temporal.logger).to receive(:error)
+
+      failure_proto = described_class.new(e, converter, serialize_whole_error: true).to_proto
+
+      expect(converter.from_details_payloads(failure_proto.application_failure_info.details)).to eq("test")
+      expect(Temporal.logger)
+        .to have_received(:error)
+        .with(
+          "Could not serialize exception details, falling back to the error message only",
+          {unserializable_error: "StandardError", error: "#<StandardError: unserializable>"}
+        )
+    end
   end
 end


### PR DESCRIPTION
If the stack trace of the error is not valid UTF-8 then the serialization was failing when building the protobuf message to send off to Temporal server.

So the thread was hard crashing because this serialization attempt was happening in the brotoful definitions in the new Temporalio SDK (which I guess is stricter or not handling bad UTF-8).